### PR TITLE
fix sqlserver2016 package not installing

### DIFF
--- a/sqlserver2016/sqlserver2016.nuspec
+++ b/sqlserver2016/sqlserver2016.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
   <metadata>
     <id>sqlserver2016</id>
-    <version>1.0.0.0</version>
+    <version>1.0.1.0</version>
     <title>SQL Server 2016</title>
     <authors>Microsoft</authors>
     <owners>seventypercent</owners>

--- a/sqlserver2016/tools/chocolateyinstall.ps1
+++ b/sqlserver2016/tools/chocolateyinstall.ps1
@@ -167,7 +167,6 @@ function ExecuteSetup(){
           -FileType 'exe' `
           -SilentArgs "/IACCEPTSQLSERVERLICENSETERMS /ConfigurationFile=$configFile" `
           -File "$setupExe" `
-          -ValidExitCodes $validExitCodes
 
     #& $setupExe "/IACCEPTSQLSERVERLICENSETERMS /ConfigurationFile=$configFile"  
 }


### PR DESCRIPTION
$validExitCodes was never set causing the package install to fail. Default value for it works fine.
