### PR TITLE
Agent Ransack: Bump to 2022.3314

### DIFF
--- a/agentransack/agentransack.nuspec
+++ b/agentransack/agentransack.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd">
   <metadata>
     <id>agentransack</id>
-    <version>2019.2951</version>
+    <version>2022.3314</version>
     <title>Agent Ransack</title>
     <authors>Mythicsoft</authors>
     <owners>seventypercent</owners>
@@ -16,12 +16,14 @@
     <copyright>Mythicsoft</copyright>
     <tags>admin</tags>
     <releaseNotes>
-* Reduced background CPU usage when idle
-* Improved parsing of MBOX/EML date time format.
-* Improved SearchTask recovery if 3rd party IFilter causes problems.
-* Bug fix: "A required resource was unavailable" error when lots of search terms (> 10,000) specified.
-* Bug fix: Relative date/time searching issues with FR/ES/NL languages.
-* Minor fixes/improvements
+* New column 'Last Saved By'.
+* Bug fix: Issue installing 32-bit portable version.
+* Bug fix: FR/ES issue with FILELIST.
+* Bug fix: Middle mouse button on tab was closing more than one tab.
+* Bug fix: Compressed archives locked until app closed.
+* Bug fix: Index monitor issue with archives and emails.
+* Bug fix: Phone searching, item selection issue.
+* Other minor fixes.
     </releaseNotes>
   </metadata>
 </package>

--- a/agentransack/tools/chocolateyInstall.ps1
+++ b/agentransack/tools/chocolateyInstall.ps1
@@ -10,10 +10,10 @@ $ErrorActionPreference = 'Stop';
 
 $packageName= 'AgentRansack'
 $toolsDir   = $(Split-Path -parent $MyInvocation.MyCommand.Definition)
-$url        = 'https://download.mythicsoft.com/flp/2951/agentransack_x86_msi_2951.zip'
-$url64      = 'https://download.mythicsoft.com/flp/2951/agentransack_x64_msi_2951.zip'
-$fileLocation = Join-Path $toolsDir 'agentransack_x86_2951.msi'
-$fileLocation64 = Join-Path $toolsDir 'agentransack_x64_2951.msi'
+$url        = 'https://download.mythicsoft.com/flp/3314/agentransack_x86_msi_3314.zip'
+$url64      = 'https://download.mythicsoft.com/flp/3314/agentransack_x64_msi_3314.zip'
+$fileLocation = Join-Path $toolsDir 'agentransack_x86_3314.msi'
+$fileLocation64 = Join-Path $toolsDir 'agentransack_x64_3314.msi'
 
 $packageArgs = @{
   packageName   = $packageName
@@ -28,9 +28,9 @@ $packageArgs = @{
   validExitCodes= @(0)
 
   softwareName  = 'AgentRansack'
-  checksum      = '32AD45EF9981C32538C0D0A51EBB281FB4C40513'
+  checksum      = '488036CCA999ED7A30ED71E1764565DDA58EB75F'
   checksumType  = 'sha1'
-  checksum64    = '8FBDFAE775905D5D8B0B87A529AAE1FE60B37B7C'
+  checksum64    = '04BE914A482DC2648D64B1E42732C2DF0DB5E39B'
   checksumType64= 'sha1'
 }
 


### PR DESCRIPTION
Increment Agent Ransack version number to 2022.3314.