### PR TITLE
Agent Ransack: Bump to 2022.3326

### DIFF
--- a/agentransack/agentransack.nuspec
+++ b/agentransack/agentransack.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd">
   <metadata>
     <id>agentransack</id>
-    <version>2022.3314</version>
+    <version>2022.3326</version>
     <title>Agent Ransack</title>
     <authors>Mythicsoft</authors>
     <owners>seventypercent</owners>
@@ -16,14 +16,14 @@
     <copyright>Mythicsoft</copyright>
     <tags>admin</tags>
     <releaseNotes>
-* New column 'Last Saved By'.
-* Bug fix: Issue installing 32-bit portable version.
-* Bug fix: FR/ES issue with FILELIST.
-* Bug fix: Middle mouse button on tab was closing more than one tab.
-* Bug fix: Compressed archives locked until app closed.
-* Bug fix: Index monitor issue with archives and emails.
-* Bug fix: Phone searching, item selection issue.
-* Other minor fixes.
+* Note: Index logs moved to local device instead of index store folder.
+* New policies DisabledSearchPaths and AllowedSearchPaths to limit permitted search paths.
+* Added MOBI file support.
+* Improved index monitor network error recovery.
+* Bug fix: Context menu keyboard functionality fixed.
+* Bug fix: Occassional crash when using 'name:' prefix on Index Search.
+* Bug fix: Favorites list sort functionality fixed.
+* Other minor changes/fixes.
     </releaseNotes>
   </metadata>
 </package>

--- a/agentransack/tools/chocolateyInstall.ps1
+++ b/agentransack/tools/chocolateyInstall.ps1
@@ -1,8 +1,8 @@
 $ErrorActionPreference = 'Stop';
 
 #cinst checksum
-#checksum -t=sha1 AgentRansack_x86_msi_nnnn.zip
-#checksum -t=sha1 AgentRansack_x64_msi_nnnn.zip
+#checksum -t=sha256 AgentRansack_x86_msi_nnnn.zip
+#checksum -t=sha256 AgentRansack_x64_msi_nnnn.zip
 
 #test with (depending if already installed):
 #cinst agentransack -s .
@@ -10,10 +10,10 @@ $ErrorActionPreference = 'Stop';
 
 $packageName= 'AgentRansack'
 $toolsDir   = $(Split-Path -parent $MyInvocation.MyCommand.Definition)
-$url        = 'https://download.mythicsoft.com/flp/3314/agentransack_x86_msi_3314.zip'
-$url64      = 'https://download.mythicsoft.com/flp/3314/agentransack_x64_msi_3314.zip'
-$fileLocation = Join-Path $toolsDir 'agentransack_x86_3314.msi'
-$fileLocation64 = Join-Path $toolsDir 'agentransack_x64_3314.msi'
+$url        = 'https://download.mythicsoft.com/flp/3326/agentransack_x86_msi_3326.zip'
+$url64      = 'https://download.mythicsoft.com/flp/3326/agentransack_x64_msi_3326.zip'
+$fileLocation = Join-Path $toolsDir 'agentransack_x86_3326.msi'
+$fileLocation64 = Join-Path $toolsDir 'agentransack_x64_3326.msi'
 
 $packageArgs = @{
   packageName   = $packageName
@@ -28,10 +28,10 @@ $packageArgs = @{
   validExitCodes= @(0)
 
   softwareName  = 'AgentRansack'
-  checksum      = '488036CCA999ED7A30ED71E1764565DDA58EB75F'
-  checksumType  = 'sha1'
-  checksum64    = '04BE914A482DC2648D64B1E42732C2DF0DB5E39B'
-  checksumType64= 'sha1'
+  checksum      = 'A8B03186C831E8085058CF745E989E1E45481E1B078F31895B08912D8F9C1738'
+  checksumType  = 'sha256'
+  checksum64    = 'F85A90AFC7DE247D2402F73BB6E669392EDCBA288EFD4241E9CF9DF35E8E1BA9'
+  checksumType64= 'sha256'
 }
 
 Install-ChocolateyZipPackage @packageArgs


### PR DESCRIPTION
Increment Agent Ransack version number to 2022.3326.