### PR TITLE
Agent Ransack: Bump to 2022.3335

### DIFF
--- a/agentransack/agentransack.nuspec
+++ b/agentransack/agentransack.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd">
   <metadata>
     <id>agentransack</id>
-    <version>2022.3326</version>
+    <version>2022.3335</version>
     <title>Agent Ransack</title>
     <authors>Mythicsoft</authors>
     <owners>seventypercent</owners>
@@ -16,13 +16,11 @@
     <copyright>Mythicsoft</copyright>
     <tags>admin</tags>
     <releaseNotes>
-* Note: Index logs moved to local device instead of index store folder.
-* New policies DisabledSearchPaths and AllowedSearchPaths to limit permitted search paths.
-* Added MOBI file support.
-* Improved index monitor network error recovery.
-* Bug fix: Context menu keyboard functionality fixed.
-* Bug fix: Occassional crash when using 'name:' prefix on Index Search.
-* Bug fix: Favorites list sort functionality fixed.
+* New columns 'File name length' and 'Path length'.
+* Improved view state restore when switching between searches.
+* Bug fix: Index search highlighting for CN, JP, KR text.
+* Bug fix: EML file encodings for non-ASCII emails.
+* Bug fix: Column filters not working properly during search.
 * Other minor changes/fixes.
     </releaseNotes>
   </metadata>

--- a/agentransack/tools/chocolateyInstall.ps1
+++ b/agentransack/tools/chocolateyInstall.ps1
@@ -10,10 +10,10 @@ $ErrorActionPreference = 'Stop';
 
 $packageName= 'AgentRansack'
 $toolsDir   = $(Split-Path -parent $MyInvocation.MyCommand.Definition)
-$url        = 'https://download.mythicsoft.com/flp/3326/agentransack_x86_msi_3326.zip'
-$url64      = 'https://download.mythicsoft.com/flp/3326/agentransack_x64_msi_3326.zip'
-$fileLocation = Join-Path $toolsDir 'agentransack_x86_3326.msi'
-$fileLocation64 = Join-Path $toolsDir 'agentransack_x64_3326.msi'
+$url        = 'https://download.mythicsoft.com/flp/3335/agentransack_x86_msi_3335.zip'
+$url64      = 'https://download.mythicsoft.com/flp/3335/agentransack_x64_msi_3335.zip'
+$fileLocation = Join-Path $toolsDir 'agentransack_x86_3335.msi'
+$fileLocation64 = Join-Path $toolsDir 'agentransack_x64_3335.msi'
 
 $packageArgs = @{
   packageName   = $packageName
@@ -28,9 +28,9 @@ $packageArgs = @{
   validExitCodes= @(0)
 
   softwareName  = 'AgentRansack'
-  checksum      = 'A8B03186C831E8085058CF745E989E1E45481E1B078F31895B08912D8F9C1738'
+  checksum      = 'D3EA553EBD5EBB404CAAF9799C96EC4BB3F4CBDF435338E2220680B5547B4AC6'
   checksumType  = 'sha256'
-  checksum64    = 'F85A90AFC7DE247D2402F73BB6E669392EDCBA288EFD4241E9CF9DF35E8E1BA9'
+  checksum64    = 'ED02B59D18767A8E2246CB120A69B972DD3C60430F84C769A9A0B025D82CFEAF'
   checksumType64= 'sha256'
 }
 


### PR DESCRIPTION
Increment Agent Ransack version number to 2022.3335.