### PR TITLE
Agent Ransack: Bump to 2022.3349

### DIFF
--- a/agentransack/agentransack.nuspec
+++ b/agentransack/agentransack.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd">
   <metadata>
     <id>agentransack</id>
-    <version>2022.3335</version>
+    <version>2022.3341</version>
     <title>Agent Ransack</title>
     <authors>Mythicsoft</authors>
     <owners>seventypercent</owners>
@@ -16,11 +16,10 @@
     <copyright>Mythicsoft</copyright>
     <tags>admin</tags>
     <releaseNotes>
-* New columns 'File name length' and 'Path length'.
-* Improved view state restore when switching between searches.
-* Bug fix: Index search highlighting for CN, JP, KR text.
-* Bug fix: EML file encodings for non-ASCII emails.
-* Bug fix: Column filters not working properly during search.
+* Updated OCR to Tesseract 5.2.
+* Bug fix: Large text settings too big for UI.
+* Bug fix: Indexer no longer overwrites index if data source unavailable.
+* Bug fix: Indexer wasn't using process priority settings.
 * Other minor changes/fixes.
     </releaseNotes>
   </metadata>

--- a/agentransack/agentransack.nuspec
+++ b/agentransack/agentransack.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd">
   <metadata>
     <id>agentransack</id>
-    <version>2022.3341</version>
+    <version>2022.3349</version>
     <title>Agent Ransack</title>
     <authors>Mythicsoft</authors>
     <owners>seventypercent</owners>
@@ -16,10 +16,12 @@
     <copyright>Mythicsoft</copyright>
     <tags>admin</tags>
     <releaseNotes>
-* Updated OCR to Tesseract 5.2.
-* Bug fix: Large text settings too big for UI.
-* Bug fix: Indexer no longer overwrites index if data source unavailable.
-* Bug fix: Indexer wasn't using process priority settings.
+* Index OCR settings now stored separately per index.
+* Indexing summary added to Messages tab.
+* Bug fix: Intermittent crash with screen reading software.
+* Bug fix: Location filters incorrectly processing back slashes.
+* Bug fix: Index search 'unexpected error' fix.
+* Bug fix: Index monitor not detecting 'offline' location source at startup.
 * Other minor changes/fixes.
     </releaseNotes>
   </metadata>

--- a/agentransack/tools/chocolateyInstall.ps1
+++ b/agentransack/tools/chocolateyInstall.ps1
@@ -10,10 +10,10 @@ $ErrorActionPreference = 'Stop';
 
 $packageName= 'AgentRansack'
 $toolsDir   = $(Split-Path -parent $MyInvocation.MyCommand.Definition)
-$url        = 'https://download.mythicsoft.com/flp/3341/agentransack_x86_msi_3341.zip'
-$url64      = 'https://download.mythicsoft.com/flp/3341/agentransack_x64_msi_3341.zip'
-$fileLocation = Join-Path $toolsDir 'agentransack_x86_3341.msi'
-$fileLocation64 = Join-Path $toolsDir 'agentransack_x64_3341.msi'
+$url        = 'https://download.mythicsoft.com/flp/3349/agentransack_x86_msi_3349.zip'
+$url64      = 'https://download.mythicsoft.com/flp/3349/agentransack_x64_msi_3349.zip'
+$fileLocation = Join-Path $toolsDir 'agentransack_x86_3349.msi'
+$fileLocation64 = Join-Path $toolsDir 'agentransack_x64_3349.msi'
 
 $packageArgs = @{
   packageName   = $packageName
@@ -28,9 +28,9 @@ $packageArgs = @{
   validExitCodes= @(0)
 
   softwareName  = 'AgentRansack'
-  checksum      = '0120F17C4A089B131B24DFAFEF5225ED32026B88B19A0DA1EAA9588B0059808F'
+  checksum      = '137EAF02563A0EE3AACC5C78DC64F08D37DDED697BD0383650F0EB04CFDAF6E2'
   checksumType  = 'sha256'
-  checksum64    = '681CD37A6193C8A2310ACFFB2155196CFB599EC45D9B7B5D037AB2BB6EFB9C55'
+  checksum64    = '8386BD1F76F47DFA64896356BA0D3CD2638B0663193F1FBFE05C1E67E7AAB9F8'
   checksumType64= 'sha256'
 }
 

--- a/agentransack/tools/chocolateyInstall.ps1
+++ b/agentransack/tools/chocolateyInstall.ps1
@@ -10,10 +10,10 @@ $ErrorActionPreference = 'Stop';
 
 $packageName= 'AgentRansack'
 $toolsDir   = $(Split-Path -parent $MyInvocation.MyCommand.Definition)
-$url        = 'https://download.mythicsoft.com/flp/3335/agentransack_x86_msi_3335.zip'
-$url64      = 'https://download.mythicsoft.com/flp/3335/agentransack_x64_msi_3335.zip'
-$fileLocation = Join-Path $toolsDir 'agentransack_x86_3335.msi'
-$fileLocation64 = Join-Path $toolsDir 'agentransack_x64_3335.msi'
+$url        = 'https://download.mythicsoft.com/flp/3341/agentransack_x86_msi_3341.zip'
+$url64      = 'https://download.mythicsoft.com/flp/3341/agentransack_x64_msi_3341.zip'
+$fileLocation = Join-Path $toolsDir 'agentransack_x86_3341.msi'
+$fileLocation64 = Join-Path $toolsDir 'agentransack_x64_3341.msi'
 
 $packageArgs = @{
   packageName   = $packageName
@@ -28,9 +28,9 @@ $packageArgs = @{
   validExitCodes= @(0)
 
   softwareName  = 'AgentRansack'
-  checksum      = 'D3EA553EBD5EBB404CAAF9799C96EC4BB3F4CBDF435338E2220680B5547B4AC6'
+  checksum      = '0120F17C4A089B131B24DFAFEF5225ED32026B88B19A0DA1EAA9588B0059808F'
   checksumType  = 'sha256'
-  checksum64    = 'ED02B59D18767A8E2246CB120A69B972DD3C60430F84C769A9A0B025D82CFEAF'
+  checksum64    = '681CD37A6193C8A2310ACFFB2155196CFB599EC45D9B7B5D037AB2BB6EFB9C55'
   checksumType64= 'sha256'
 }
 


### PR DESCRIPTION
Increment Agent Ransack version number to 2022.3341.

Let's hope it works this time...