### PR TITLE
Agent Ransack: Bump to 2022.3367

### DIFF
--- a/agentransack/agentransack.nuspec
+++ b/agentransack/agentransack.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd">
   <metadata>
     <id>agentransack</id>
-    <version>2022.3349</version>
+    <version>2022.3366</version>
     <title>Agent Ransack</title>
     <authors>Mythicsoft</authors>
     <owners>seventypercent</owners>
@@ -16,12 +16,16 @@
     <copyright>Mythicsoft</copyright>
     <tags>admin</tags>
     <releaseNotes>
-* Index OCR settings now stored separately per index.
-* Indexing summary added to Messages tab.
-* Bug fix: Intermittent crash with screen reading software.
-* Bug fix: Location filters incorrectly processing back slashes.
-* Bug fix: Index search 'unexpected error' fix.
-* Bug fix: Index monitor not detecting 'offline' location source at startup.
+* New: Bulk Copy now supports copying folders.
+* New: Single-instance mode (Shell Configuration).
+* Improved EXIF details for PNG and JPG files.
+* OCR page orientation detection.
+* Summary keyword report speed improvements.
+* Indexing can support larger documents.
+* Visual Studio 2022 supported as external editor.
+* Bug fix: Occassional index search delays between searches.
+* Bug fix: Docking/undocking window restore issues.
+* Bug fix: Context menu rename was not working.
 * Other minor changes/fixes.
     </releaseNotes>
   </metadata>

--- a/agentransack/agentransack.nuspec
+++ b/agentransack/agentransack.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd">
   <metadata>
     <id>agentransack</id>
-    <version>2022.3366</version>
+    <version>2022.3367</version>
     <title>Agent Ransack</title>
     <authors>Mythicsoft</authors>
     <owners>seventypercent</owners>
@@ -16,16 +16,9 @@
     <copyright>Mythicsoft</copyright>
     <tags>admin</tags>
     <releaseNotes>
-* New: Bulk Copy now supports copying folders.
-* New: Single-instance mode (Shell Configuration).
-* Improved EXIF details for PNG and JPG files.
-* OCR page orientation detection.
-* Summary keyword report speed improvements.
-* Indexing can support larger documents.
-* Visual Studio 2022 supported as external editor.
-* Bug fix: Occassional index search delays between searches.
-* Bug fix: Docking/undocking window restore issues.
-* Bug fix: Context menu rename was not working.
+* Bug fix: Index searching with column filters was causing focus issue.
+* Bug fix: EXIF reading issues on some images.
+* Bug fix: Possible truncation of text with OCR on PDFs with text.
 * Other minor changes/fixes.
     </releaseNotes>
   </metadata>

--- a/agentransack/tools/chocolateyInstall.ps1
+++ b/agentransack/tools/chocolateyInstall.ps1
@@ -10,10 +10,10 @@ $ErrorActionPreference = 'Stop';
 
 $packageName= 'AgentRansack'
 $toolsDir   = $(Split-Path -parent $MyInvocation.MyCommand.Definition)
-$url        = 'https://download.mythicsoft.com/flp/3349/agentransack_x86_msi_3349.zip'
-$url64      = 'https://download.mythicsoft.com/flp/3349/agentransack_x64_msi_3349.zip'
-$fileLocation = Join-Path $toolsDir 'agentransack_x86_3349.msi'
-$fileLocation64 = Join-Path $toolsDir 'agentransack_x64_3349.msi'
+$url        = 'https://download.mythicsoft.com/flp/3366/agentransack_x86_msi_3366.zip'
+$url64      = 'https://download.mythicsoft.com/flp/3366/agentransack_x64_msi_3366.zip'
+$fileLocation = Join-Path $toolsDir 'agentransack_x86_3366.msi'
+$fileLocation64 = Join-Path $toolsDir 'agentransack_x64_3366.msi'
 
 $packageArgs = @{
   packageName   = $packageName
@@ -28,9 +28,9 @@ $packageArgs = @{
   validExitCodes= @(0)
 
   softwareName  = 'AgentRansack'
-  checksum      = '137EAF02563A0EE3AACC5C78DC64F08D37DDED697BD0383650F0EB04CFDAF6E2'
+  checksum      = '7C421A5047802A7149A4A1CFC5E79C7F7DA55A4EB0A54D989EBAEC8D434527B3'
   checksumType  = 'sha256'
-  checksum64    = '8386BD1F76F47DFA64896356BA0D3CD2638B0663193F1FBFE05C1E67E7AAB9F8'
+  checksum64    = '98C70218E65D5AE9B3D4646FB5B42441FCA275460EFC6EAE5B24B422F8E835E0'
   checksumType64= 'sha256'
 }
 

--- a/agentransack/tools/chocolateyInstall.ps1
+++ b/agentransack/tools/chocolateyInstall.ps1
@@ -10,10 +10,10 @@ $ErrorActionPreference = 'Stop';
 
 $packageName= 'AgentRansack'
 $toolsDir   = $(Split-Path -parent $MyInvocation.MyCommand.Definition)
-$url        = 'https://download.mythicsoft.com/flp/3366/agentransack_x86_msi_3366.zip'
-$url64      = 'https://download.mythicsoft.com/flp/3366/agentransack_x64_msi_3366.zip'
-$fileLocation = Join-Path $toolsDir 'agentransack_x86_3366.msi'
-$fileLocation64 = Join-Path $toolsDir 'agentransack_x64_3366.msi'
+$url        = 'https://download.mythicsoft.com/flp/3367/agentransack_x86_msi_3367.zip'
+$url64      = 'https://download.mythicsoft.com/flp/3367/agentransack_x64_msi_3367.zip'
+$fileLocation = Join-Path $toolsDir 'agentransack_x86_3367.msi'
+$fileLocation64 = Join-Path $toolsDir 'agentransack_x64_3367.msi'
 
 $packageArgs = @{
   packageName   = $packageName
@@ -28,9 +28,9 @@ $packageArgs = @{
   validExitCodes= @(0)
 
   softwareName  = 'AgentRansack'
-  checksum      = '7C421A5047802A7149A4A1CFC5E79C7F7DA55A4EB0A54D989EBAEC8D434527B3'
+  checksum      = 'fa10ef357fa94674c75ac600d036a43559889eb046f6959ae9c5e9f321f4f984'
   checksumType  = 'sha256'
-  checksum64    = '98C70218E65D5AE9B3D4646FB5B42441FCA275460EFC6EAE5B24B422F8E835E0'
+  checksum64    = 'f2ab079a406c37404f330e50a8acf672b8e47332d138790754cc2d0796fdaab2'
   checksumType64= 'sha256'
 }
 


### PR DESCRIPTION
Increment Agent Ransack version number to 2022.3366.

The package has [already been pushed](https://community.chocolatey.org/packages/agentransack/2022.3366).

