### PR TITLE
Agent Ransack: Bump to 2022.3389

### DIFF
--- a/agentransack/agentransack.nuspec
+++ b/agentransack/agentransack.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd">
   <metadata>
     <id>agentransack</id>
-    <version>2022.3367</version>
+    <version>2022.3389</version>
     <title>Agent Ransack</title>
     <authors>Mythicsoft</authors>
     <owners>seventypercent</owners>
@@ -16,9 +16,14 @@
     <copyright>Mythicsoft</copyright>
     <tags>admin</tags>
     <releaseNotes>
-* Bug fix: Index searching with column filters was causing focus issue.
-* Bug fix: EXIF reading issues on some images.
-* Bug fix: Possible truncation of text with OCR on PDFs with text.
+* Bug fix: Hits not displaying with case-sensitive index NEAR search.
+* Bug fix: Contents view not sized correctly.
+* Bug fix: Expression editor was incorrectly concatenating values.
+* New: Edit history option in History settings.
+* Bug fix: Index settings changes were not being saved if monitoring active.
+* Bug fix: Long running index updates could fail with 'This IndexWriter is closed'.
+* Bug fix: Column widths and views were not restoring properly.
+* Bug fix: PDF/OCR issues when document paths included non-ASCII characters.
 * Other minor changes/fixes.
     </releaseNotes>
   </metadata>

--- a/agentransack/tools/chocolateyInstall.ps1
+++ b/agentransack/tools/chocolateyInstall.ps1
@@ -10,10 +10,10 @@ $ErrorActionPreference = 'Stop';
 
 $packageName= 'AgentRansack'
 $toolsDir   = $(Split-Path -parent $MyInvocation.MyCommand.Definition)
-$url        = 'https://download.mythicsoft.com/flp/3367/agentransack_x86_msi_3367.zip'
-$url64      = 'https://download.mythicsoft.com/flp/3367/agentransack_x64_msi_3367.zip'
-$fileLocation = Join-Path $toolsDir 'agentransack_x86_3367.msi'
-$fileLocation64 = Join-Path $toolsDir 'agentransack_x64_3367.msi'
+$url        = 'https://download.mythicsoft.com/flp/3389/agentransack_x86_msi_3389.zip'
+$url64      = 'https://download.mythicsoft.com/flp/3389/agentransack_x64_msi_3389.zip'
+$fileLocation = Join-Path $toolsDir 'agentransack_x86_3389.msi'
+$fileLocation64 = Join-Path $toolsDir 'agentransack_x64_3389.msi'
 
 $packageArgs = @{
   packageName   = $packageName
@@ -28,9 +28,9 @@ $packageArgs = @{
   validExitCodes= @(0)
 
   softwareName  = 'AgentRansack'
-  checksum      = 'fa10ef357fa94674c75ac600d036a43559889eb046f6959ae9c5e9f321f4f984'
+  checksum      = 'A0667CBC13688288F54F420C5C9AA4A6DC8D2208D58193350DEE61352F185D65'
   checksumType  = 'sha256'
-  checksum64    = 'f2ab079a406c37404f330e50a8acf672b8e47332d138790754cc2d0796fdaab2'
+  checksum64    = 'C9052951C547990354DA2616581D5646F62D83081668A4BA3580361A68DAFAAC'
   checksumType64= 'sha256'
 }
 


### PR DESCRIPTION
Increment Agent Ransack version number to 2022.3389.

The package has [already been pushed](https://community.chocolatey.org/packages/agentransack/2022.3389).