### PR TITLE
Agent Ransack: Bump to 2022.3405

### DIFF
--- a/agentransack/agentransack.nuspec
+++ b/agentransack/agentransack.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd">
   <metadata>
     <id>agentransack</id>
-    <version>2022.3389</version>
+    <version>2022.3405</version>
     <title>Agent Ransack</title>
     <authors>Mythicsoft</authors>
     <owners>seventypercent</owners>
@@ -16,14 +16,11 @@
     <copyright>Mythicsoft</copyright>
     <tags>admin</tags>
     <releaseNotes>
-* Bug fix: Hits not displaying with case-sensitive index NEAR search.
-* Bug fix: Contents view not sized correctly.
-* Bug fix: Expression editor was incorrectly concatenating values.
-* New: Edit history option in History settings.
-* Bug fix: Index settings changes were not being saved if monitoring active.
-* Bug fix: Long running index updates could fail with 'This IndexWriter is closed'.
-* Bug fix: Column widths and views were not restoring properly.
-* Bug fix: PDF/OCR issues when document paths included non-ASCII characters.
+* Added 'Last refresh' date to index list.
+* Text tab scrolls right to show more characters after a hit.
+* LastAccessedDate and CreatedDate added to .NET API.
+* Bug fix: Long path support for reading raw data from Office docs.
+* Bug fix: Lite mode report styles incorrectly shown as disabled.
 * Other minor changes/fixes.
     </releaseNotes>
   </metadata>

--- a/agentransack/tools/chocolateyInstall.ps1
+++ b/agentransack/tools/chocolateyInstall.ps1
@@ -10,10 +10,10 @@ $ErrorActionPreference = 'Stop';
 
 $packageName= 'AgentRansack'
 $toolsDir   = $(Split-Path -parent $MyInvocation.MyCommand.Definition)
-$url        = 'https://download.mythicsoft.com/flp/3389/agentransack_x86_msi_3389.zip'
-$url64      = 'https://download.mythicsoft.com/flp/3389/agentransack_x64_msi_3389.zip'
-$fileLocation = Join-Path $toolsDir 'agentransack_x86_3389.msi'
-$fileLocation64 = Join-Path $toolsDir 'agentransack_x64_3389.msi'
+$url        = 'https://download.mythicsoft.com/flp/3405/agentransack_x86_msi_3405.zip'
+$url64      = 'https://download.mythicsoft.com/flp/3405/agentransack_x64_msi_3405.zip'
+$fileLocation = Join-Path $toolsDir 'agentransack_x86_3405.msi'
+$fileLocation64 = Join-Path $toolsDir 'agentransack_x64_3405.msi'
 
 $packageArgs = @{
   packageName   = $packageName
@@ -28,9 +28,9 @@ $packageArgs = @{
   validExitCodes= @(0)
 
   softwareName  = 'AgentRansack'
-  checksum      = 'A0667CBC13688288F54F420C5C9AA4A6DC8D2208D58193350DEE61352F185D65'
+  checksum      = '720540EC0901521F41F1882633697570D1D0EC95BE81754C7F807836C585811C'
   checksumType  = 'sha256'
-  checksum64    = 'C9052951C547990354DA2616581D5646F62D83081668A4BA3580361A68DAFAAC'
+  checksum64    = '76FEE8FDC9B6E84F563DD3F3A300B8F2328C381CAF2F829C293AE9B508EC8493'
   checksumType64= 'sha256'
 }
 


### PR DESCRIPTION
Increment Agent Ransack version number to 2022.3405.

The package has [already been pushed](https://community.chocolatey.org/packages/agentransack/2022.3405.0).