### PR TITLE
Agent Ransack: Bump to 2022.3406

### DIFF
--- a/agentransack/agentransack.nuspec
+++ b/agentransack/agentransack.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd">
   <metadata>
     <id>agentransack</id>
-    <version>2022.3405</version>
+    <version>2022.3406</version>
     <title>Agent Ransack</title>
     <authors>Mythicsoft</authors>
     <owners>seventypercent</owners>
@@ -16,12 +16,7 @@
     <copyright>Mythicsoft</copyright>
     <tags>admin</tags>
     <releaseNotes>
-* Added 'Last refresh' date to index list.
-* Text tab scrolls right to show more characters after a hit.
-* LastAccessedDate and CreatedDate added to .NET API.
-* Bug fix: Long path support for reading raw data from Office docs.
-* Bug fix: Lite mode report styles incorrectly shown as disabled.
-* Other minor changes/fixes.
+* Bug fix: Image preview sometimes not working with OneDrive.
     </releaseNotes>
   </metadata>
 </package>

--- a/agentransack/tools/chocolateyInstall.ps1
+++ b/agentransack/tools/chocolateyInstall.ps1
@@ -5,15 +5,15 @@ $ErrorActionPreference = 'Stop';
 #checksum -t=sha256 AgentRansack_x64_msi_nnnn.zip
 
 #test with (depending if already installed):
-#cinst agentransack -s .
-#cup agentransack -s .
+#choco install agentransack -s .
+#choco upgrade agentransack -s .
 
 $packageName= 'AgentRansack'
 $toolsDir   = $(Split-Path -parent $MyInvocation.MyCommand.Definition)
-$url        = 'https://download.mythicsoft.com/flp/3405/agentransack_x86_msi_3405.zip'
-$url64      = 'https://download.mythicsoft.com/flp/3405/agentransack_x64_msi_3405.zip'
-$fileLocation = Join-Path $toolsDir 'agentransack_x86_3405.msi'
-$fileLocation64 = Join-Path $toolsDir 'agentransack_x64_3405.msi'
+$url        = 'https://download.mythicsoft.com/flp/3406/agentransack_x86_msi_3406.zip'
+$url64      = 'https://download.mythicsoft.com/flp/3406/agentransack_x64_msi_3406.zip'
+$fileLocation = Join-Path $toolsDir 'agentransack_x86_3406.msi'
+$fileLocation64 = Join-Path $toolsDir 'agentransack_x64_3406.msi'
 
 $packageArgs = @{
   packageName   = $packageName
@@ -28,9 +28,9 @@ $packageArgs = @{
   validExitCodes= @(0)
 
   softwareName  = 'AgentRansack'
-  checksum      = '720540EC0901521F41F1882633697570D1D0EC95BE81754C7F807836C585811C'
+  checksum      = '4FA1BA366309F7B6E97802AE7BADA408C5E34EFD00F73567DEFD2847D4E87083'
   checksumType  = 'sha256'
-  checksum64    = '76FEE8FDC9B6E84F563DD3F3A300B8F2328C381CAF2F829C293AE9B508EC8493'
+  checksum64    = '8E09B21B07E05BEA63B750B5B35149A9B67727E6B1A5F2768AA29EF380A6B300'
   checksumType64= 'sha256'
 }
 


### PR DESCRIPTION
Increment Agent Ransack version number to 2022.3406.

The package has [already been pushed](https://community.chocolatey.org/packages/agentransack/2022.3406.0).