### PR TITLE
Agent Ransack: Bump to 2022.3420

### DIFF
--- a/agentransack/agentransack.nuspec
+++ b/agentransack/agentransack.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd">
   <metadata>
     <id>agentransack</id>
-    <version>2022.3418</version>
+    <version>2022.3420</version>
     <title>Agent Ransack</title>
     <authors>Mythicsoft</authors>
     <owners>seventypercent</owners>
@@ -16,9 +16,11 @@
     <copyright>Mythicsoft</copyright>
     <tags>admin</tags>
     <releaseNotes>
-* Root archive file (eg file.zip) now displays a list of contents in Text Tab.
-* Bug fix: Empty file warning was preventing file from appearing in result.
-* Revert (3416): Removed CET compatible setting due to issues with 3rd party modules.
+* Improved List View scroll speed.
+* New policy DisableCrashReportSending to stop crash reports being sent to Mythicsoft.
+* Bug fix: Expression editor issue handling '\(' in regex.
+* Bug fix: Issue with Boolean expressions where only NOT specified.
+* Bug fix: Contents view out of sync with highlighted file when using TAB after rename.
     </releaseNotes>
   </metadata>
 </package>

--- a/agentransack/tools/chocolateyInstall.ps1
+++ b/agentransack/tools/chocolateyInstall.ps1
@@ -10,10 +10,10 @@ $ErrorActionPreference = 'Stop';
 
 $packageName= 'AgentRansack'
 $toolsDir   = $(Split-Path -parent $MyInvocation.MyCommand.Definition)
-$url        = 'https://download.mythicsoft.com/flp/3418/agentransack_x86_msi_3418.zip'
-$url64      = 'https://download.mythicsoft.com/flp/3418/agentransack_x64_msi_3418.zip'
-$fileLocation = Join-Path $toolsDir 'agentransack_x86_3418.msi'
-$fileLocation64 = Join-Path $toolsDir 'agentransack_x64_3418.msi'
+$url        = 'https://download.mythicsoft.com/flp/3420/agentransack_x86_msi_3420.zip'
+$url64      = 'https://download.mythicsoft.com/flp/3420/agentransack_x64_msi_3420.zip'
+$fileLocation = Join-Path $toolsDir 'agentransack_x86_3420.msi'
+$fileLocation64 = Join-Path $toolsDir 'agentransack_x64_3420.msi'
 
 $packageArgs = @{
   packageName   = $packageName
@@ -28,9 +28,9 @@ $packageArgs = @{
   validExitCodes= @(0)
 
   softwareName  = 'AgentRansack'
-  checksum      = 'b321468de2aaef60d71ea62bb1005ec9a85f8e01be82b7bb5ba48a8f74b820fa'
+  checksum      = '654151a23f388d72e64dc274a60c145a75c0fd68dcada3246b313d402cae39e7'
   checksumType  = 'sha256'
-  checksum64    = '107f91735614092aa82cd2a03f1093ec1ecd6a3260c8669a1f8127821d0cabff'
+  checksum64    = '6277a68d8adb4eb47e0389a6b0540ce99a9fc12bb6f21f42731524216072cc3a'
   checksumType64= 'sha256'
 }
 


### PR DESCRIPTION
Increment [Agent Ransack version number to 2022.3420](https://www.mythicsoft.com/agentransack/information/#version-history).

The package has [already been pushed](https://community.chocolatey.org/packages/agentransack/2022.3420.0).