### PR TITLE
Agent Ransack: Bump to 2022.3434

### DIFF
--- a/agentransack/agentransack.nuspec
+++ b/agentransack/agentransack.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd">
   <metadata>
     <id>agentransack</id>
-    <version>2022.3425</version>
+    <version>2022.3434</version>
     <title>Agent Ransack</title>
     <authors>Mythicsoft</authors>
     <owners>seventypercent</owners>
@@ -16,9 +16,10 @@
     <copyright>Mythicsoft</copyright>
     <tags>admin</tags>
     <releaseNotes>
-* Bug fix: Indexing stuck in 'Analyzing' state when error occurs.
-* Bug fix: Anchored text in index search not highlighting correctly.
-* Bug fix: Zoomed text tab not displaying line numbers properly.
+* New: .one (OneNote) file support.
+* Bug fix: Index update was incorrectly re-indexing unchanged files.
+* Bug fix: Owner column was not showing results for folders.
+* Bug fix: Index Manager - Last refresh column was not sorting properly.
 * Other minor changes/fixes.
     </releaseNotes>
   </metadata>

--- a/agentransack/tools/chocolateyInstall.ps1
+++ b/agentransack/tools/chocolateyInstall.ps1
@@ -1,6 +1,6 @@
 $ErrorActionPreference = 'Stop';
 
-#cinst checksum
+#choco install checksum
 #checksum -t=sha256 AgentRansack_x86_msi_nnnn.zip
 #checksum -t=sha256 AgentRansack_x64_msi_nnnn.zip
 
@@ -10,10 +10,10 @@ $ErrorActionPreference = 'Stop';
 
 $packageName= 'AgentRansack'
 $toolsDir   = $(Split-Path -parent $MyInvocation.MyCommand.Definition)
-$url        = 'https://download.mythicsoft.com/flp/3425/agentransack_x86_msi_3425.zip'
-$url64      = 'https://download.mythicsoft.com/flp/3425/agentransack_x64_msi_3425.zip'
-$fileLocation = Join-Path $toolsDir 'agentransack_x86_3425.msi'
-$fileLocation64 = Join-Path $toolsDir 'agentransack_x64_3425.msi'
+$url        = 'https://download.mythicsoft.com/flp/3434/agentransack_x86_msi_3434.zip'
+$url64      = 'https://download.mythicsoft.com/flp/3434/agentransack_x64_msi_3434.zip'
+$fileLocation = Join-Path $toolsDir 'agentransack_x86_3434.msi'
+$fileLocation64 = Join-Path $toolsDir 'agentransack_x64_3434.msi'
 
 $packageArgs = @{
   packageName   = $packageName
@@ -28,9 +28,9 @@ $packageArgs = @{
   validExitCodes= @(0)
 
   softwareName  = 'AgentRansack'
-  checksum      = 'fbcac0869e3712bec63a2939c62596b53d268a5b1b0ebf04928a7825d89c2e9d'
+  checksum      = '6600e17684eecebd3af974fc761dcb15fc4bee47e7f80419ad52c0b61fa5f0a1'
   checksumType  = 'sha256'
-  checksum64    = '37c266037f4445c513a5fd0dbda5d841933228303f1a92d9947708c6ea5a3ecc'
+  checksum64    = '21ba767bc9c1b20360abca4e846f42a21056af082b49788abd28f1ecb3dfc5ea'
   checksumType64= 'sha256'
 }
 


### PR DESCRIPTION
Increment [Agent Ransack version number to 2022.3434](https://www.mythicsoft.com/agentransack/information/#version-history).

The package has [already been pushed](https://community.chocolatey.org/packages/agentransack/2022.3434.0).