### PR TITLE
Agent Ransack: Bump to 2022.3499

### DIFF
--- a/agentransack/agentransack.nuspec
+++ b/agentransack/agentransack.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd">
   <metadata>
     <id>agentransack</id>
-    <version>2022.3435</version>
+    <version>2022.3499</version>
     <title>Agent Ransack</title>
     <authors>Mythicsoft</authors>
     <owners>seventypercent</owners>
@@ -16,7 +16,15 @@
     <copyright>Mythicsoft</copyright>
     <tags>admin</tags>
     <releaseNotes>
-* Bug fix: Issue with file viewer causing application to close.
+* New: PDF Preview highlighting.
+* New: Normalize stylized quotes as regular quotes when searching.
+* Added command line flag to specify which archive types are active in index.
+* Option to customize tab title.
+* Bug fix: Improve index list loading speed.
+* Bug fix: Display issue fixed with large multi-folder lists.
+* Bug fix: Potential crash with complex multi-line regex searches.
+* Other minor changes/fixes.
+* Bug fix: Using multi-folder button during index edit causes other fields to be reset.
     </releaseNotes>
   </metadata>
 </package>

--- a/agentransack/tools/chocolateyInstall.ps1
+++ b/agentransack/tools/chocolateyInstall.ps1
@@ -10,10 +10,10 @@ $ErrorActionPreference = 'Stop';
 
 $packageName= 'AgentRansack'
 $toolsDir   = $(Split-Path -parent $MyInvocation.MyCommand.Definition)
-$url        = 'https://download.mythicsoft.com/flp/3435/agentransack_x86_msi_3435.zip'
-$url64      = 'https://download.mythicsoft.com/flp/3435/agentransack_x64_msi_3435.zip'
-$fileLocation = Join-Path $toolsDir 'agentransack_x86_3435.msi'
-$fileLocation64 = Join-Path $toolsDir 'agentransack_x64_3435.msi'
+$url        = 'https://download.mythicsoft.com/flp/3499/agentransack_x86_msi_3499.zip'
+$url64      = 'https://download.mythicsoft.com/flp/3499/agentransack_x64_msi_3499.zip'
+$fileLocation = Join-Path $toolsDir 'agentransack_x86_3499.msi'
+$fileLocation64 = Join-Path $toolsDir 'agentransack_x64_3499.msi'
 
 $packageArgs = @{
   packageName   = $packageName
@@ -28,9 +28,9 @@ $packageArgs = @{
   validExitCodes= @(0)
 
   softwareName  = 'AgentRansack'
-  checksum      = '4b160c0ee06e5d10ea4c31326eabae1b90a308509f52750db9c9d2986f66bd94'
+  checksum      = '194eb20b216f5fae2c33366e19ec9b7048b0264bb1cef70ad51e642cd5cb2900'
   checksumType  = 'sha256'
-  checksum64    = 'f288d43238ba323526e6fc6702f2e61afd1e7f8bcbee4f2bcee208817968a5f7'
+  checksum64    = '44cfc8877cc416e8c184893a106799b8b47a97ac54e7b284a0d917be18e655a9'
   checksumType64= 'sha256'
 }
 


### PR DESCRIPTION
Increment [Agent Ransack version number to 2022.3499](https://www.mythicsoft.com/agentransack/information/#version-history).

The package has [already been pushed](https://community.chocolatey.org/packages/agentransack/2022.3499.0).