### PR TITLE
Agent Ransack: Bump to 2022.3517

### DIFF
--- a/agentransack/agentransack.nuspec
+++ b/agentransack/agentransack.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd">
   <metadata>
     <id>agentransack</id>
-    <version>2022.3503</version>
+    <version>2022.3517</version>
     <title>Agent Ransack</title>
     <authors>Mythicsoft</authors>
     <owners>seventypercent</owners>
@@ -16,8 +16,13 @@
     <copyright>Mythicsoft</copyright>
     <tags>admin</tags>
     <releaseNotes>
-* Bug fix: EPUB indexing/searching hit count incorrect.
-* Bug fix: NEAR term highlighting with PDF Preview not working.
+* Improved Favorites list keyboard support.
+* Name column now displays leading spaces of file name if appropriate.
+* Support for Unix LF with MBOX files added.
+* New '-safe' switch for trouble-shooting start-up issues.
+* Bug fix: PDF Documents no longer locked for deletion when displayed in Preview tab.
+* Bug fix: Dragging from Explorer title bar into Look In field was causing issues with recent versions of Windows.
+* Bug fix: Clear history now deletes record of last search.
 * Other minor changes/fixes.
     </releaseNotes>
   </metadata>

--- a/agentransack/tools/chocolateyInstall.ps1
+++ b/agentransack/tools/chocolateyInstall.ps1
@@ -10,10 +10,10 @@ $ErrorActionPreference = 'Stop';
 
 $packageName= 'AgentRansack'
 $toolsDir   = $(Split-Path -parent $MyInvocation.MyCommand.Definition)
-$url        = 'https://download.mythicsoft.com/flp/3503/agentransack_x86_msi_3503.zip'
-$url64      = 'https://download.mythicsoft.com/flp/3503/agentransack_x64_msi_3503.zip'
-$fileLocation = Join-Path $toolsDir 'agentransack_x86_3503.msi'
-$fileLocation64 = Join-Path $toolsDir 'agentransack_x64_3503.msi'
+$url        = 'https://download.mythicsoft.com/flp/3517/agentransack_x86_msi_3517.zip'
+$url64      = 'https://download.mythicsoft.com/flp/3517/agentransack_x64_msi_3517.zip'
+$fileLocation = Join-Path $toolsDir 'agentransack_x86_3517.msi'
+$fileLocation64 = Join-Path $toolsDir 'agentransack_x64_3517.msi'
 
 $packageArgs = @{
   packageName   = $packageName
@@ -28,9 +28,9 @@ $packageArgs = @{
   validExitCodes= @(0)
 
   softwareName  = 'AgentRansack'
-  checksum      = 'c92a2b3fd2478732856b63409a3bd9a110f1745e5f3d953c7f03994357b48bd1'
+  checksum      = '972dff9faa42c1771279b13976bae0825b6f3583400a28bcb28a98e71abcd77f'
   checksumType  = 'sha256'
-  checksum64    = 'a40b42a2e06e88e5573893dba6d0f13754a513670150172185fee0e56d449a79'
+  checksum64    = '98577db3b1087c42c46768748a1e815d2a51a225f8dcb1876e86b305d1ffaa9b'
   checksumType64= 'sha256'
 }
 


### PR DESCRIPTION
Increment [Agent Ransack version number to 2022.3517](https://www.mythicsoft.com/agentransack/information/#version-history).

The package has [already been pushed](https://community.chocolatey.org/packages/agentransack/2022.3517.0).