### PR TITLE
Agent Ransack: Bump to 2022.3522

### DIFF
--- a/agentransack/agentransack.nuspec
+++ b/agentransack/agentransack.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd">
   <metadata>
     <id>agentransack</id>
-    <version>2022.3517</version>
+    <version>2022.3522</version>
     <title>Agent Ransack</title>
     <authors>Mythicsoft</authors>
     <owners>seventypercent</owners>
@@ -16,13 +16,12 @@
     <copyright>Mythicsoft</copyright>
     <tags>admin</tags>
     <releaseNotes>
-* Improved Favorites list keyboard support.
-* Name column now displays leading spaces of file name if appropriate.
-* Support for Unix LF with MBOX files added.
-* New '-safe' switch for trouble-shooting start-up issues.
-* Bug fix: PDF Documents no longer locked for deletion when displayed in Preview tab.
-* Bug fix: Dragging from Explorer title bar into Look In field was causing issues with recent versions of Windows.
-* Bug fix: Clear history now deletes record of last search.
+* Policies can now be stored in HKLM as well as HKCU.
+* Option for always-on safe mode - fixes issue with Explorer Patcher.
+* Bug fix: Microsoft Purview (Office365) generated PST files can now be searched properly.
+* Bug fix: Combobox truncation issue with long strings.
+* Bug fix: Copying Error list to clipboard issue.
+* Bug fix: .NET library issue with saving/loading criteria files.
 * Other minor changes/fixes.
     </releaseNotes>
   </metadata>

--- a/agentransack/tools/chocolateyInstall.ps1
+++ b/agentransack/tools/chocolateyInstall.ps1
@@ -10,10 +10,10 @@ $ErrorActionPreference = 'Stop';
 
 $packageName= 'AgentRansack'
 $toolsDir   = $(Split-Path -parent $MyInvocation.MyCommand.Definition)
-$url        = 'https://download.mythicsoft.com/flp/3517/agentransack_x86_msi_3517.zip'
-$url64      = 'https://download.mythicsoft.com/flp/3517/agentransack_x64_msi_3517.zip'
-$fileLocation = Join-Path $toolsDir 'agentransack_x86_3517.msi'
-$fileLocation64 = Join-Path $toolsDir 'agentransack_x64_3517.msi'
+$url        = 'https://download.mythicsoft.com/flp/3522/agentransack_x86_msi_3522.zip'
+$url64      = 'https://download.mythicsoft.com/flp/3522/agentransack_x64_msi_3522.zip'
+$fileLocation = Join-Path $toolsDir 'agentransack_x86_3522.msi'
+$fileLocation64 = Join-Path $toolsDir 'agentransack_x64_3522.msi'
 
 $packageArgs = @{
   packageName   = $packageName
@@ -28,9 +28,9 @@ $packageArgs = @{
   validExitCodes= @(0)
 
   softwareName  = 'AgentRansack'
-  checksum      = '972dff9faa42c1771279b13976bae0825b6f3583400a28bcb28a98e71abcd77f'
+  checksum      = '59cd396fb49c0451253672f9dca30c55a16d1134af1b39be864ab54c352cf303'
   checksumType  = 'sha256'
-  checksum64    = '98577db3b1087c42c46768748a1e815d2a51a225f8dcb1876e86b305d1ffaa9b'
+  checksum64    = '3c568ee9cdfb6aa69c9181d9f91c5b445c8271daa12e8e127fe87761b17286d7'
   checksumType64= 'sha256'
 }
 


### PR DESCRIPTION
Increment [Agent Ransack version number to 2022.3522](https://www.mythicsoft.com/agentransack/information/#version-history).

The package has [already been pushed](https://community.chocolatey.org/packages/agentransack/2022.3522.0).