### PR TITLE
Agent Ransack: Bump to 2022.3536

### DIFF
--- a/agentransack/agentransack.nuspec
+++ b/agentransack/agentransack.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd">
   <metadata>
     <id>agentransack</id>
-    <version>2022.3530</version>
+    <version>2022.3536</version>
     <title>Agent Ransack</title>
     <authors>Mythicsoft</authors>
     <owners>seventypercent</owners>
@@ -16,12 +16,9 @@
     <copyright>Mythicsoft</copyright>
     <tags>admin</tags>
     <releaseNotes>
-* Mythicsoft.Search.Core.Dll is now separate download (issues with A/V false positives).
-* Bug fix: Favorites not always loading correctly for index searches.
-* PDF Preview supports keyboard navigation.
-* Improved Contents View sizing logic.
-* Updated MSVC libs to latest version.
-* Bug fix: PDF temp files used for OCR not always deleted appropriately.
+* Bug fix: Possible crash when previewing some PDFs.
+* Bug fix: Paused searches not restarting properly with toolbar Start.
+* Bug fix: Improved dialog layout on high DPI screens.
 * Other minor changes/fixes.
     </releaseNotes>
   </metadata>

--- a/agentransack/tools/chocolateyInstall.ps1
+++ b/agentransack/tools/chocolateyInstall.ps1
@@ -10,10 +10,10 @@ $ErrorActionPreference = 'Stop';
 
 $packageName= 'AgentRansack'
 $toolsDir   = $(Split-Path -parent $MyInvocation.MyCommand.Definition)
-$url        = 'https://download.mythicsoft.com/flp/3530/agentransack_x86_msi_3530.zip'
-$url64      = 'https://download.mythicsoft.com/flp/3530/agentransack_x64_msi_3530.zip'
-$fileLocation = Join-Path $toolsDir 'agentransack_x86_3530.msi'
-$fileLocation64 = Join-Path $toolsDir 'agentransack_x64_3530.msi'
+$url        = 'https://download.mythicsoft.com/flp/3536/agentransack_x86_msi_3536.zip'
+$url64      = 'https://download.mythicsoft.com/flp/3536/agentransack_x64_msi_3536.zip'
+$fileLocation = Join-Path $toolsDir 'agentransack_x86_3536.msi'
+$fileLocation64 = Join-Path $toolsDir 'agentransack_x64_3536.msi'
 
 $packageArgs = @{
   packageName   = $packageName
@@ -28,9 +28,9 @@ $packageArgs = @{
   validExitCodes= @(0)
 
   softwareName  = 'AgentRansack'
-  checksum      = '7877170efac93b1d6a2da920dd51b5ea23298613e90d625baabf775111f33f99'
+  checksum      = '1d67aeb46a4fdb8a7318502d44d62b90fa4f81cf9d5856328bc6c7160dd60b58'
   checksumType  = 'sha256'
-  checksum64    = '23ec37f22eccf35d8c1b452e9c509776a86fbeb2a461e1cfc00e5105cf1d7d59'
+  checksum64    = 'c032c9b1b1aa3c219791a60eecc5ed6006ac4b76ce5bab6bd7a465952e4fb631'
   checksumType64= 'sha256'
 }
 


### PR DESCRIPTION
Increment [Agent Ransack version number to 2022.3536](https://www.mythicsoft.com/agentransack/information/#version-history).

The package has [already been pushed](https://community.chocolatey.org/packages/agentransack/2022.3536.0).