### PR TITLE
Agent Ransack: Bump to 2022.3544

### DIFF
--- a/agentransack/agentransack.nuspec
+++ b/agentransack/agentransack.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd">
   <metadata>
     <id>agentransack</id>
-    <version>2022.3536</version>
+    <version>2022.3544</version>
     <title>Agent Ransack</title>
     <authors>Mythicsoft</authors>
     <owners>seventypercent</owners>
@@ -16,9 +16,11 @@
     <copyright>Mythicsoft</copyright>
     <tags>admin</tags>
     <releaseNotes>
-* Bug fix: Possible crash when previewing some PDFs.
-* Bug fix: Paused searches not restarting properly with toolbar Start.
-* Bug fix: Improved dialog layout on high DPI screens.
+* Bug fix: File list was being hidden in some situations.
+* Bug fix: PDF Preview could crash with invalid PDFs.
+* Bug fix: Index monitor could fail if MyMusic folder not defined.
+* Bug fix: Temp files could be left if file conversion failed.
+* Bug fix: Term color dialog showing duplicate terms.
 * Other minor changes/fixes.
     </releaseNotes>
   </metadata>

--- a/agentransack/tools/chocolateyInstall.ps1
+++ b/agentransack/tools/chocolateyInstall.ps1
@@ -10,10 +10,10 @@ $ErrorActionPreference = 'Stop';
 
 $packageName= 'AgentRansack'
 $toolsDir   = $(Split-Path -parent $MyInvocation.MyCommand.Definition)
-$url        = 'https://download.mythicsoft.com/flp/3536/agentransack_x86_msi_3536.zip'
-$url64      = 'https://download.mythicsoft.com/flp/3536/agentransack_x64_msi_3536.zip'
-$fileLocation = Join-Path $toolsDir 'agentransack_x86_3536.msi'
-$fileLocation64 = Join-Path $toolsDir 'agentransack_x64_3536.msi'
+$url        = 'https://download.mythicsoft.com/flp/3544/agentransack_x86_msi_3544.zip'
+$url64      = 'https://download.mythicsoft.com/flp/3544/agentransack_x64_msi_3544.zip'
+$fileLocation = Join-Path $toolsDir 'agentransack_x86_3544.msi'
+$fileLocation64 = Join-Path $toolsDir 'agentransack_x64_3544.msi'
 
 $packageArgs = @{
   packageName   = $packageName
@@ -28,9 +28,9 @@ $packageArgs = @{
   validExitCodes= @(0)
 
   softwareName  = 'AgentRansack'
-  checksum      = '1d67aeb46a4fdb8a7318502d44d62b90fa4f81cf9d5856328bc6c7160dd60b58'
+  checksum      = '09155a4b3446955c4a6b0a7ee68b0ddc0c11e56efe495452ff9200dcd42487c5'
   checksumType  = 'sha256'
-  checksum64    = 'c032c9b1b1aa3c219791a60eecc5ed6006ac4b76ce5bab6bd7a465952e4fb631'
+  checksum64    = 'f3524cd4b121da21758a78fd438204d921c3e05e87e91261accaaa4e1a7c9809'
   checksumType64= 'sha256'
 }
 


### PR DESCRIPTION
Increment [Agent Ransack version number to 2022.3544](https://www.mythicsoft.com/agentransack/information/#version-history).

The package has [already been pushed](https://community.chocolatey.org/packages/agentransack/2022.3544.0).