### PR TITLE
Agent Ransack: Bump to 2022.3555

### DIFF
--- a/agentransack/agentransack.nuspec
+++ b/agentransack/agentransack.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd">
   <metadata>
     <id>agentransack</id>
-    <version>2022.3544</version>
+    <version>2022.3555</version>
     <title>Agent Ransack</title>
     <authors>Mythicsoft</authors>
     <owners>seventypercent</owners>
@@ -16,11 +16,11 @@
     <copyright>Mythicsoft</copyright>
     <tags>admin</tags>
     <releaseNotes>
-* Bug fix: File list was being hidden in some situations.
-* Bug fix: PDF Preview could crash with invalid PDFs.
-* Bug fix: Index monitor could fail if MyMusic folder not defined.
-* Bug fix: Temp files could be left if file conversion failed.
-* Bug fix: Term color dialog showing duplicate terms.
+* Added policy management for index operations.
+* Bug fix: Favorites filter case-sensitive issues
+* Bug fix: Calendar appointments not displaying properly.
+* Bug fix: flpidx display issues with German localization.
+* Bug fix: Dark style text display improvements.
 * Other minor changes/fixes.
     </releaseNotes>
   </metadata>

--- a/agentransack/tools/chocolateyInstall.ps1
+++ b/agentransack/tools/chocolateyInstall.ps1
@@ -10,10 +10,10 @@ $ErrorActionPreference = 'Stop';
 
 $packageName= 'AgentRansack'
 $toolsDir   = $(Split-Path -parent $MyInvocation.MyCommand.Definition)
-$url        = 'https://download.mythicsoft.com/flp/3544/agentransack_x86_msi_3544.zip'
-$url64      = 'https://download.mythicsoft.com/flp/3544/agentransack_x64_msi_3544.zip'
-$fileLocation = Join-Path $toolsDir 'agentransack_x86_3544.msi'
-$fileLocation64 = Join-Path $toolsDir 'agentransack_x64_3544.msi'
+$url        = 'https://download.mythicsoft.com/flp/3555/wzn-fyf5-HDG-mgW/agentransack_x86_msi_3555.zip'
+$url64      = 'https://download.mythicsoft.com/flp/3555/wzn-fyf5-HDG-mgW/agentransack_x64_msi_3555.zip'
+$fileLocation = Join-Path $toolsDir 'agentransack_x86_3555.msi'
+$fileLocation64 = Join-Path $toolsDir 'agentransack_x64_3555.msi'
 
 $packageArgs = @{
   packageName   = $packageName
@@ -28,9 +28,9 @@ $packageArgs = @{
   validExitCodes= @(0)
 
   softwareName  = 'AgentRansack'
-  checksum      = '09155a4b3446955c4a6b0a7ee68b0ddc0c11e56efe495452ff9200dcd42487c5'
+  checksum      = 'fd62cecfe2ad7767116917f525a5e6f99327bb1e40d04de3b6c5c4f23ced664f'
   checksumType  = 'sha256'
-  checksum64    = 'f3524cd4b121da21758a78fd438204d921c3e05e87e91261accaaa4e1a7c9809'
+  checksum64    = 'c78bd72c85071a5bde5016b42a57ed17ecb8218a807c9d8ab30fd0657f2ead5a'
   checksumType64= 'sha256'
 }
 


### PR DESCRIPTION
Increment [Agent Ransack version number to 2022.3555](https://www.mythicsoft.com/agentransack/information/#version-history).

The package has [already been pushed](https://community.chocolatey.org/packages/agentransack/2022.3555.0).